### PR TITLE
Remove unstable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait,unboxed_closures)]
 #![allow(
     non_camel_case_types,
     non_upper_case_globals,
@@ -15,26 +14,16 @@ extern crate image;
 use image::ImageBuffer;
 
 pub extern crate ul_sys as ul;
-pub mod helpers;
 pub mod config;
+pub mod helpers;
 
-use helpers::{
-    evaluate_script,
-    set_js_object_property,
-    create_js_function,
-};
+use helpers::{create_js_function, evaluate_script, set_js_object_property};
 
-use std::{
-    option::NoneError,
-    os::raw::c_void,
-};
+use std::os::raw::c_void;
 
 mod helpers_internal;
-use helpers_internal::{
-    log_forward_cb,
-    unpack_closure_view_cb,
-};
 use crate::helpers_internal::unpack_window_resize_cb;
+use helpers_internal::{log_forward_cb, unpack_closure_view_cb};
 
 pub type App = ul::ULApp;
 pub type Config = config::UltralightConfig;
@@ -43,6 +32,9 @@ pub type Overlay = ul::ULOverlay;
 pub type Renderer = ul::ULRenderer;
 pub type View = ul::ULView;
 pub type Window = ul::ULWindow;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub struct NoneError {}
 
 /*
     Current flow
@@ -108,14 +100,14 @@ pub struct UltralightApp {
     // to obtain a non-main monitor
     monitor: Monitor,
     overlay: Option<Overlay>,
-    window: Option<Window>
+    window: Option<Window>,
 }
 
 impl UltralightApp {
     pub fn new(config: Option<Config>) -> UltralightApp {
         let ulconfig = match config {
             Some(config) => config,
-            None => Config::new()
+            None => Config::new(),
         };
 
         unsafe {
@@ -160,45 +152,32 @@ impl UltralightApp {
             window_flags ^= 0b1000;
         }
 
-        let window = unsafe {
-            ul::ulCreateWindow(
-                self.monitor,
-                height,
-                width,
-                fullscreen,
-                window_flags
-            )
-        };
+        let window =
+            unsafe { ul::ulCreateWindow(self.monitor, height, width, fullscreen, window_flags) };
 
         unsafe {
             ul::ulAppSetWindow(self.app, window);
         }
 
-        let overlay = unsafe {
-            ul::ulCreateOverlay(window, width, height, 0, 0)
-        };
+        let overlay = unsafe { ul::ulCreateOverlay(window, width, height, 0, 0) };
 
         self.window = Some(window);
         self.overlay = Some(overlay);
     }
 
     pub fn get_renderer(&mut self) -> Renderer {
-        unsafe {
-            ul::ulAppGetRenderer(self.app)
-        }
+        unsafe { ul::ulAppGetRenderer(self.app) }
     }
 
     pub fn get_view(&mut self) -> Result<View, NoneError> {
-        unsafe {
-            Ok(ul::ulOverlayGetView(self.overlay?))
-        }
+        unsafe { Ok(ul::ulOverlayGetView(self.overlay.ok_or(NoneError {})?)) }
     }
 
     pub fn set_window_title(&mut self, title: &str) -> Result<(), NoneError> {
         unsafe {
             ul::ulWindowSetTitle(
-                self.window?,
-                std::ffi::CString::new(title).unwrap().as_ptr()
+                self.window.ok_or(NoneError {})?,
+                std::ffi::CString::new(title).unwrap().as_ptr(),
             );
         }
 
@@ -207,25 +186,23 @@ impl UltralightApp {
 
     pub fn resize_overlay(&self, width: u32, height: u32) -> Result<(), NoneError> {
         unsafe {
-            ul::ulOverlayResize(self.overlay?, width, height);
+            ul::ulOverlayResize(self.overlay.ok_or(NoneError {})?, width, height);
         }
 
         Ok(())
     }
 
     pub fn set_window_resize_callback<T>(&self, mut cb: T) -> Result<(), NoneError>
-        where T: FnMut(u32, u32)
+    where
+        T: FnMut(u32, u32),
     {
         unsafe {
-            let (
-                cb_closure,
-                cb_function
-            ) = unpack_window_resize_cb(&mut cb);
+            let (cb_closure, cb_function) = unpack_window_resize_cb(&mut cb);
 
             ul::ulWindowSetResizeCallback(
-                self.window?,
+                self.window.ok_or(NoneError {})?,
                 Some(cb_function),
-                cb_closure
+                cb_closure,
             );
         }
 
@@ -249,29 +226,23 @@ impl Ultralight {
     pub fn new(config: Option<Config>, renderer: Option<Renderer>) -> Ultralight {
         let ulconfig = match config {
             Some(config) => config,
-            None => Config::new()
+            None => Config::new(),
         };
 
         let used_renderer = match renderer {
             Some(renderer) => renderer,
-            None => {
-                unsafe {
-                    ul::ulCreateRenderer(ulconfig.to_ulconfig())
-                }
-            }
+            None => unsafe { ul::ulCreateRenderer(ulconfig.to_ulconfig()) },
         };
 
         Ultralight {
             config: ulconfig,
             renderer: used_renderer,
-            view: None
+            view: None,
         }
     }
 
     pub fn set_view(&mut self, view: View) {
-        unsafe {
-            self.view = Some(view);
-        }
+        self.view = Some(view);
     }
 
     pub fn view(&mut self, width: u32, height: u32, transparent: bool) {
@@ -284,7 +255,7 @@ impl Ultralight {
         unsafe {
             let url_ulstr = helpers_internal::ul_string(url);
 
-            ul::ulViewLoadURL(self.view?, url_ulstr);
+            ul::ulViewLoadURL(self.view.ok_or(NoneError {})?, url_ulstr);
         }
 
         Ok(())
@@ -294,7 +265,7 @@ impl Ultralight {
         unsafe {
             let code_ulstr = helpers_internal::ul_string(code);
 
-            ul::ulViewLoadHTML(self.view?, code_ulstr);
+            ul::ulViewLoadHTML(self.view.ok_or(NoneError {})?, code_ulstr);
         }
 
         Ok(())
@@ -308,7 +279,7 @@ impl Ultralight {
 
     pub fn update_until_loaded(&mut self) -> Result<(), NoneError> {
         unsafe {
-            while ul::ulViewIsLoading(self.view?) {
+            while ul::ulViewIsLoading(self.view.ok_or(NoneError {})?) {
                 ul::ulUpdate(self.renderer);
             }
         }
@@ -327,10 +298,10 @@ impl Ultralight {
             let scrollEvent = ul::ulCreateScrollEvent(
                 ul::ULScrollEventType_kScrollEventType_ScrollByPixel,
                 delta_x,
-                delta_y
+                delta_y,
             );
 
-            ul::ulViewFireScrollEvent(self.view?, scrollEvent);
+            ul::ulViewFireScrollEvent(self.view.ok_or(NoneError {})?, scrollEvent);
 
             ul::ulDestroyScrollEvent(scrollEvent);
 
@@ -340,53 +311,41 @@ impl Ultralight {
 
     pub fn get_scroll_height(&mut self) -> Result<f64, NoneError> {
         unsafe {
-            let (jsgctx, _) = helpers::getJSContextFromView(self.view?);
+            let (jsgctx, _) = helpers::getJSContextFromView(self.view.ok_or(NoneError {})?);
 
             Ok(ul::JSValueToNumber(
                 jsgctx,
                 self.evaluate_script("document.body.scrollHeight").unwrap(),
-                std::ptr::null_mut()
+                std::ptr::null_mut(),
             ))
         }
     }
 
     pub fn set_finish_loading_callback<T>(&mut self, mut cb: T) -> Result<(), NoneError>
-        where T: FnMut(View)
+    where
+        T: FnMut(View),
     {
-        let view = self.view?;
+        let view = self.view.ok_or(NoneError {})?;
 
         unsafe {
-            let (
-                cb_closure,
-                cb_function
-            ) = unpack_closure_view_cb(&mut cb);
+            let (cb_closure, cb_function) = unpack_closure_view_cb(&mut cb);
 
-            ul::ulViewSetFinishLoadingCallback(
-                view,
-                Some(cb_function),
-                cb_closure
-            );
+            ul::ulViewSetFinishLoadingCallback(view, Some(cb_function), cb_closure);
         }
 
         Ok(())
     }
 
     pub fn set_dom_ready_callback<T>(&mut self, mut cb: T) -> Result<(), NoneError>
-        where T: FnMut(View)
+    where
+        T: FnMut(View),
     {
-        let view = self.view?;
+        let view = self.view.ok_or(NoneError {})?;
 
         unsafe {
-            let (
-                cb_closure,
-                cb_function
-            ) = unpack_closure_view_cb(&mut cb);
+            let (cb_closure, cb_function) = unpack_closure_view_cb(&mut cb);
 
-            ul::ulViewSetDOMReadyCallback(
-                view,
-                Some(cb_function),
-                cb_closure
-            );
+            ul::ulViewSetDOMReadyCallback(view, Some(cb_function), cb_closure);
         }
 
         Ok(())
@@ -395,58 +354,47 @@ impl Ultralight {
     pub fn create_function<T>(
         &mut self,
         name: &'static str,
-        hook: &mut T
+        hook: &mut T,
     ) -> Result<ul::JSObjectRef, NoneError>
-        where T: FnMut(
+    where
+        T: FnMut(
             ul::JSContextRef,
             ul::JSObjectRef,
             ul::JSObjectRef,
             usize,
             *const ul::JSValueRef,
             *mut ul::JSValueRef,
-        ) -> ul::JSValueRef
+        ) -> ul::JSValueRef,
     {
-        Ok(
-            create_js_function(
-                self.view?,
-                name,
-                hook
-            )
-        )
+        Ok(create_js_function(
+            self.view.ok_or(NoneError {})?,
+            name,
+            hook,
+        ))
     }
 
     pub fn set_js_object_property(
         &mut self,
         name: &'static str,
-        object: ul::JSObjectRef
+        object: ul::JSObjectRef,
     ) -> Result<(), NoneError> {
-        set_js_object_property(
-            self.view?,
-            name,
-            object
-        );
+        set_js_object_property(self.view.ok_or(NoneError {})?, name, object);
 
         Ok(())
     }
 
-    pub fn evaluate_script(
-        &mut self,
-        script: &'static str,
-    ) -> Result<ul::JSValueRef, NoneError> {
-        Ok(evaluate_script(self.view?, script))
+    pub fn evaluate_script(&mut self, script: &'static str) -> Result<ul::JSValueRef, NoneError> {
+        Ok(evaluate_script(self.view.ok_or(NoneError {})?, script))
     }
 
     pub fn get_raw_pixels(&mut self) -> Result<Vec<u8>, NoneError> {
         unsafe {
-            let bitmap_obj = ul::ulViewGetBitmap( self.view? );
+            let bitmap_obj = ul::ulViewGetBitmap(self.view.ok_or(NoneError {})?);
 
             let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
             let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
 
-            let bitmap_raw = std::slice::from_raw_parts_mut(
-                bitmap as *mut u8,
-                bitmap_size,
-            );
+            let bitmap_raw = std::slice::from_raw_parts_mut(bitmap as *mut u8, bitmap_size);
 
             ul::ulBitmapUnlockPixels(bitmap_obj);
 
@@ -454,47 +402,34 @@ impl Ultralight {
         }
     }
 
-    pub fn write_png_to_file(
-        &mut self,
-        file_name: &'static str,
-    ) -> Result<bool, NoneError> {
+    pub fn write_png_to_file(&mut self, file_name: &'static str) -> Result<bool, NoneError> {
         unsafe {
-            let bitmap_obj = ul::ulViewGetBitmap( self.view? );
+            let bitmap_obj = ul::ulViewGetBitmap(self.view.ok_or(NoneError {})?);
 
             let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
             let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
 
-            let bitmap_raw = std::slice::from_raw_parts_mut(
-                bitmap as *mut u8,
-                bitmap_size,
-            );
+            let bitmap_raw = std::slice::from_raw_parts_mut(bitmap as *mut u8, bitmap_size);
 
             let fn_c_str = std::ffi::CString::new(file_name).unwrap();
 
-            Ok(
-                ul::ulBitmapWritePNG(
-                    bitmap_obj,
-                    fn_c_str.as_ptr()
-                )
-            )
+            Ok(ul::ulBitmapWritePNG(bitmap_obj, fn_c_str.as_ptr()))
         }
     }
 
     pub fn is_loading(&self) -> bool {
         match self.view {
-            Some(view) => unsafe {
-                ul::ulViewIsLoading(view)
-            },
-            None => false
+            Some(view) => unsafe { ul::ulViewIsLoading(view) },
+            None => false,
         }
     }
 
     pub fn log_to_stdout(&mut self) -> Result<(), NoneError> {
         unsafe {
             ul::ulViewSetAddConsoleMessageCallback(
-                self.view?,
+                self.view.ok_or(NoneError {})?,
                 Some(log_forward_cb),
-                std::ptr::null_mut() as *mut c_void
+                std::ptr::null_mut() as *mut c_void,
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(try_trait,unboxed_closures)]
 #![allow(
     non_camel_case_types,
     non_upper_case_globals,
@@ -14,16 +15,26 @@ extern crate image;
 use image::ImageBuffer;
 
 pub extern crate ul_sys as ul;
-pub mod config;
 pub mod helpers;
+pub mod config;
 
-use helpers::{create_js_function, evaluate_script, set_js_object_property};
+use helpers::{
+    evaluate_script,
+    set_js_object_property,
+    create_js_function,
+};
 
-use std::{fmt::Debug, os::raw::c_void};
+use std::{
+    option::NoneError,
+    os::raw::c_void,
+};
 
 mod helpers_internal;
+use helpers_internal::{
+    log_forward_cb,
+    unpack_closure_view_cb,
+};
 use crate::helpers_internal::unpack_window_resize_cb;
-use helpers_internal::{log_forward_cb, unpack_closure_view_cb};
 
 pub type App = ul::ULApp;
 pub type Config = config::UltralightConfig;
@@ -97,14 +108,14 @@ pub struct UltralightApp {
     // to obtain a non-main monitor
     monitor: Monitor,
     overlay: Option<Overlay>,
-    window: Option<Window>,
+    window: Option<Window>
 }
 
 impl UltralightApp {
     pub fn new(config: Option<Config>) -> UltralightApp {
         let ulconfig = match config {
             Some(config) => config,
-            None => Config::new(),
+            None => Config::new()
         };
 
         unsafe {
@@ -149,70 +160,76 @@ impl UltralightApp {
             window_flags ^= 0b1000;
         }
 
-        let window =
-            unsafe { ul::ulCreateWindow(self.monitor, height, width, fullscreen, window_flags) };
+        let window = unsafe {
+            ul::ulCreateWindow(
+                self.monitor,
+                height,
+                width,
+                fullscreen,
+                window_flags
+            )
+        };
 
         unsafe {
             ul::ulAppSetWindow(self.app, window);
         }
 
-        let overlay = unsafe { ul::ulCreateOverlay(window, width, height, 0, 0) };
+        let overlay = unsafe {
+            ul::ulCreateOverlay(window, width, height, 0, 0)
+        };
 
         self.window = Some(window);
         self.overlay = Some(overlay);
     }
 
     pub fn get_renderer(&mut self) -> Renderer {
-        unsafe { ul::ulAppGetRenderer(self.app) }
-    }
-
-    pub fn get_view(&mut self) -> Result<View, ()> {
-        if let Some(overlay) = self.overlay {
-            unsafe { Ok(ul::ulOverlayGetView(overlay)) }
-        } else {
-            Err(())
+        unsafe {
+            ul::ulAppGetRenderer(self.app)
         }
     }
 
-    pub fn set_window_title(&mut self, title: &str) -> Result<(), ()> {
-        if let Some(window) = self.window {
-            unsafe {
-                ul::ulWindowSetTitle(window, std::ffi::CString::new(title).unwrap().as_ptr());
-            }
-
-            Ok(())
-        } else {
-            Err(())
+    pub fn get_view(&mut self) -> Result<View, NoneError> {
+        unsafe {
+            Ok(ul::ulOverlayGetView(self.overlay?))
         }
     }
 
-    pub fn resize_overlay(&self, width: u32, height: u32) -> Result<(), ()> {
-        if let Some(overlay) = self.overlay {
-            unsafe {
-                ul::ulOverlayResize(overlay, width, height);
-            }
-
-            Ok(())
-        } else {
-            Err(())
+    pub fn set_window_title(&mut self, title: &str) -> Result<(), NoneError> {
+        unsafe {
+            ul::ulWindowSetTitle(
+                self.window?,
+                std::ffi::CString::new(title).unwrap().as_ptr()
+            );
         }
+
+        Ok(())
     }
 
-    pub fn set_window_resize_callback<T>(&self, mut cb: T) -> Result<(), ()>
-    where
-        T: FnMut(u32, u32),
+    pub fn resize_overlay(&self, width: u32, height: u32) -> Result<(), NoneError> {
+        unsafe {
+            ul::ulOverlayResize(self.overlay?, width, height);
+        }
+
+        Ok(())
+    }
+
+    pub fn set_window_resize_callback<T>(&self, mut cb: T) -> Result<(), NoneError>
+        where T: FnMut(u32, u32)
     {
-        if let Some(window) = self.window {
-            unsafe {
-                let (cb_closure, cb_function) = unpack_window_resize_cb(&mut cb);
+        unsafe {
+            let (
+                cb_closure,
+                cb_function
+            ) = unpack_window_resize_cb(&mut cb);
 
-                ul::ulWindowSetResizeCallback(window, Some(cb_function), cb_closure);
-            }
-
-            Ok(())
-        } else {
-            Err(())
+            ul::ulWindowSetResizeCallback(
+                self.window?,
+                Some(cb_function),
+                cb_closure
+            );
         }
+
+        Ok(())
     }
 
     pub fn run(&mut self) {
@@ -232,18 +249,22 @@ impl Ultralight {
     pub fn new(config: Option<Config>, renderer: Option<Renderer>) -> Ultralight {
         let ulconfig = match config {
             Some(config) => config,
-            None => Config::new(),
+            None => Config::new()
         };
 
         let used_renderer = match renderer {
             Some(renderer) => renderer,
-            None => unsafe { ul::ulCreateRenderer(ulconfig.to_ulconfig()) },
+            None => {
+                unsafe {
+                    ul::ulCreateRenderer(ulconfig.to_ulconfig())
+                }
+            }
         };
 
         Ultralight {
             config: ulconfig,
             renderer: used_renderer,
-            view: None,
+            view: None
         }
     }
 
@@ -259,32 +280,24 @@ impl Ultralight {
         }
     }
 
-    pub fn load_url(&mut self, url: &'static str) -> Result<(), ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                let url_ulstr = helpers_internal::ul_string(url);
+    pub fn load_url(&mut self, url: &'static str) -> Result<(), NoneError> {
+        unsafe {
+            let url_ulstr = helpers_internal::ul_string(url);
 
-                ul::ulViewLoadURL(view, url_ulstr);
-            }
-
-            Ok(())
-        } else {
-            Err(())
+            ul::ulViewLoadURL(self.view?, url_ulstr);
         }
+
+        Ok(())
     }
 
-    pub fn load_html(&mut self, code: &'static str) -> Result<(), ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                let code_ulstr = helpers_internal::ul_string(code);
+    pub fn load_html(&mut self, code: &'static str) -> Result<(), NoneError> {
+        unsafe {
+            let code_ulstr = helpers_internal::ul_string(code);
 
-                ul::ulViewLoadHTML(view, code_ulstr);
-            }
-
-            Ok(())
-        } else {
-            Err(())
+            ul::ulViewLoadHTML(self.view?, code_ulstr);
         }
+
+        Ok(())
     }
 
     pub fn update(&mut self) {
@@ -293,18 +306,14 @@ impl Ultralight {
         }
     }
 
-    pub fn update_until_loaded(&mut self) -> Result<(), ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                while ul::ulViewIsLoading(view) {
-                    ul::ulUpdate(self.renderer);
-                }
+    pub fn update_until_loaded(&mut self) -> Result<(), NoneError> {
+        unsafe {
+            while ul::ulViewIsLoading(self.view?) {
+                ul::ulUpdate(self.renderer);
             }
-
-            Ok(())
-        } else {
-            Err(())
         }
+
+        Ok(())
     }
 
     pub fn render(&mut self) {
@@ -313,178 +322,182 @@ impl Ultralight {
         }
     }
 
-    pub fn scroll(&mut self, delta_x: i32, delta_y: i32) -> Result<(), ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                let scrollEvent = ul::ulCreateScrollEvent(
-                    ul::ULScrollEventType_kScrollEventType_ScrollByPixel,
-                    delta_x,
-                    delta_y,
-                );
+    pub fn scroll(&mut self, delta_x: i32, delta_y: i32) -> Result<(), NoneError> {
+        unsafe {
+            let scrollEvent = ul::ulCreateScrollEvent(
+                ul::ULScrollEventType_kScrollEventType_ScrollByPixel,
+                delta_x,
+                delta_y
+            );
 
-                ul::ulViewFireScrollEvent(view, scrollEvent);
+            ul::ulViewFireScrollEvent(self.view?, scrollEvent);
 
-                ul::ulDestroyScrollEvent(scrollEvent);
-
-                Ok(())
-            }
-        } else {
-            Err(())
-        }
-    }
-
-    pub fn get_scroll_height(&mut self) -> Result<f64, ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                let (jsgctx, _) = helpers::getJSContextFromView(view);
-
-                Ok(ul::JSValueToNumber(
-                    jsgctx,
-                    self.evaluate_script("document.body.scrollHeight").unwrap(),
-                    std::ptr::null_mut(),
-                ))
-            }
-        } else {
-            Err(())
-        }
-    }
-
-    pub fn set_finish_loading_callback<T>(&mut self, mut cb: T) -> Result<(), ()>
-    where
-        T: FnMut(View),
-    {
-        if let Some(view) = self.view {
-            unsafe {
-                let (cb_closure, cb_function) = unpack_closure_view_cb(&mut cb);
-
-                ul::ulViewSetFinishLoadingCallback(view, Some(cb_function), cb_closure);
-            }
+            ul::ulDestroyScrollEvent(scrollEvent);
 
             Ok(())
-        } else {
-            Err(())
         }
     }
 
-    pub fn set_dom_ready_callback<T>(&mut self, mut cb: T) -> Result<(), ()>
-    where
-        T: FnMut(View),
-    {
-        if let Some(view) = self.view {
-            unsafe {
-                let (cb_closure, cb_function) = unpack_closure_view_cb(&mut cb);
+    pub fn get_scroll_height(&mut self) -> Result<f64, NoneError> {
+        unsafe {
+            let (jsgctx, _) = helpers::getJSContextFromView(self.view?);
 
-                ul::ulViewSetDOMReadyCallback(view, Some(cb_function), cb_closure);
-            }
-
-            Ok(())
-        } else {
-            Err(())
+            Ok(ul::JSValueToNumber(
+                jsgctx,
+                self.evaluate_script("document.body.scrollHeight").unwrap(),
+                std::ptr::null_mut()
+            ))
         }
+    }
+
+    pub fn set_finish_loading_callback<T>(&mut self, mut cb: T) -> Result<(), NoneError>
+        where T: FnMut(View)
+    {
+        let view = self.view?;
+
+        unsafe {
+            let (
+                cb_closure,
+                cb_function
+            ) = unpack_closure_view_cb(&mut cb);
+
+            ul::ulViewSetFinishLoadingCallback(
+                view,
+                Some(cb_function),
+                cb_closure
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn set_dom_ready_callback<T>(&mut self, mut cb: T) -> Result<(), NoneError>
+        where T: FnMut(View)
+    {
+        let view = self.view?;
+
+        unsafe {
+            let (
+                cb_closure,
+                cb_function
+            ) = unpack_closure_view_cb(&mut cb);
+
+            ul::ulViewSetDOMReadyCallback(
+                view,
+                Some(cb_function),
+                cb_closure
+            );
+        }
+
+        Ok(())
     }
 
     pub fn create_function<T>(
         &mut self,
         name: &'static str,
-        hook: &mut T,
-    ) -> Result<ul::JSObjectRef, ()>
-    where
-        T: FnMut(
+        hook: &mut T
+    ) -> Result<ul::JSObjectRef, NoneError>
+        where T: FnMut(
             ul::JSContextRef,
             ul::JSObjectRef,
             ul::JSObjectRef,
             usize,
             *const ul::JSValueRef,
             *mut ul::JSValueRef,
-        ) -> ul::JSValueRef,
+        ) -> ul::JSValueRef
     {
-        if let Some(view) = self.view {
-            Ok(create_js_function(view, name, hook))
-        } else {
-            Err(())
-        }
+        Ok(
+            create_js_function(
+                self.view?,
+                name,
+                hook
+            )
+        )
     }
 
     pub fn set_js_object_property(
         &mut self,
         name: &'static str,
-        object: ul::JSObjectRef,
-    ) -> Result<(), ()> {
-        if let Some(view) = self.view {
-            set_js_object_property(view, name, object);
+        object: ul::JSObjectRef
+    ) -> Result<(), NoneError> {
+        set_js_object_property(
+            self.view?,
+            name,
+            object
+        );
 
-            Ok(())
-        } else {
-            Err(())
+        Ok(())
+    }
+
+    pub fn evaluate_script(
+        &mut self,
+        script: &'static str,
+    ) -> Result<ul::JSValueRef, NoneError> {
+        Ok(evaluate_script(self.view?, script))
+    }
+
+    pub fn get_raw_pixels(&mut self) -> Result<Vec<u8>, NoneError> {
+        unsafe {
+            let bitmap_obj = ul::ulViewGetBitmap( self.view? );
+
+            let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
+            let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
+
+            let bitmap_raw = std::slice::from_raw_parts_mut(
+                bitmap as *mut u8,
+                bitmap_size,
+            );
+
+            ul::ulBitmapUnlockPixels(bitmap_obj);
+
+            Ok(bitmap_raw.to_vec())
         }
     }
 
-    pub fn evaluate_script(&mut self, script: &'static str) -> Result<ul::JSValueRef, ()> {
-        if let Some(view) = self.view {
-            Ok(evaluate_script(view, script))
-        } else {
-            Err(())
-        }
-    }
+    pub fn write_png_to_file(
+        &mut self,
+        file_name: &'static str,
+    ) -> Result<bool, NoneError> {
+        unsafe {
+            let bitmap_obj = ul::ulViewGetBitmap( self.view? );
 
-    pub fn get_raw_pixels(&mut self) -> Result<Vec<u8>, ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                let bitmap_obj = ul::ulViewGetBitmap(view);
+            let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
+            let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
 
-                let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
-                let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
+            let bitmap_raw = std::slice::from_raw_parts_mut(
+                bitmap as *mut u8,
+                bitmap_size,
+            );
 
-                let bitmap_raw = std::slice::from_raw_parts_mut(bitmap as *mut u8, bitmap_size);
+            let fn_c_str = std::ffi::CString::new(file_name).unwrap();
 
-                ul::ulBitmapUnlockPixels(bitmap_obj);
-
-                Ok(bitmap_raw.to_vec())
-            }
-        } else {
-            Err(())
-        }
-    }
-
-    pub fn write_png_to_file(&mut self, file_name: &'static str) -> Result<bool, ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                let bitmap_obj = ul::ulViewGetBitmap(view);
-
-                let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
-                let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
-
-                let bitmap_raw = std::slice::from_raw_parts_mut(bitmap as *mut u8, bitmap_size);
-
-                let fn_c_str = std::ffi::CString::new(file_name).unwrap();
-
-                Ok(ul::ulBitmapWritePNG(bitmap_obj, fn_c_str.as_ptr()))
-            }
-        } else {
-            Err(())
+            Ok(
+                ul::ulBitmapWritePNG(
+                    bitmap_obj,
+                    fn_c_str.as_ptr()
+                )
+            )
         }
     }
 
     pub fn is_loading(&self) -> bool {
         match self.view {
-            Some(view) => unsafe { ul::ulViewIsLoading(view) },
-            None => false,
+            Some(view) => unsafe {
+                ul::ulViewIsLoading(view)
+            },
+            None => false
         }
     }
 
-    pub fn log_to_stdout(&mut self) -> Result<(), ()> {
-        if let Some(view) = self.view {
-            unsafe {
-                ul::ulViewSetAddConsoleMessageCallback(
-                    view,
-                    Some(log_forward_cb),
-                    std::ptr::null_mut() as *mut c_void,
-                );
-            }
-
-            Ok(())
-        } else {
-            Err(())
+    pub fn log_to_stdout(&mut self) -> Result<(), NoneError> {
+        unsafe {
+            ul::ulViewSetAddConsoleMessageCallback(
+                self.view?,
+                Some(log_forward_cb),
+                std::ptr::null_mut() as *mut c_void
+            );
         }
+
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait,unboxed_closures)]
 #![allow(
     non_camel_case_types,
     non_upper_case_globals,
@@ -15,26 +14,16 @@ extern crate image;
 use image::ImageBuffer;
 
 pub extern crate ul_sys as ul;
-pub mod helpers;
 pub mod config;
+pub mod helpers;
 
-use helpers::{
-    evaluate_script,
-    set_js_object_property,
-    create_js_function,
-};
+use helpers::{create_js_function, evaluate_script, set_js_object_property};
 
-use std::{
-    option::NoneError,
-    os::raw::c_void,
-};
+use std::{fmt::Debug, os::raw::c_void};
 
 mod helpers_internal;
-use helpers_internal::{
-    log_forward_cb,
-    unpack_closure_view_cb,
-};
 use crate::helpers_internal::unpack_window_resize_cb;
+use helpers_internal::{log_forward_cb, unpack_closure_view_cb};
 
 pub type App = ul::ULApp;
 pub type Config = config::UltralightConfig;
@@ -108,14 +97,14 @@ pub struct UltralightApp {
     // to obtain a non-main monitor
     monitor: Monitor,
     overlay: Option<Overlay>,
-    window: Option<Window>
+    window: Option<Window>,
 }
 
 impl UltralightApp {
     pub fn new(config: Option<Config>) -> UltralightApp {
         let ulconfig = match config {
             Some(config) => config,
-            None => Config::new()
+            None => Config::new(),
         };
 
         unsafe {
@@ -160,76 +149,70 @@ impl UltralightApp {
             window_flags ^= 0b1000;
         }
 
-        let window = unsafe {
-            ul::ulCreateWindow(
-                self.monitor,
-                height,
-                width,
-                fullscreen,
-                window_flags
-            )
-        };
+        let window =
+            unsafe { ul::ulCreateWindow(self.monitor, height, width, fullscreen, window_flags) };
 
         unsafe {
             ul::ulAppSetWindow(self.app, window);
         }
 
-        let overlay = unsafe {
-            ul::ulCreateOverlay(window, width, height, 0, 0)
-        };
+        let overlay = unsafe { ul::ulCreateOverlay(window, width, height, 0, 0) };
 
         self.window = Some(window);
         self.overlay = Some(overlay);
     }
 
     pub fn get_renderer(&mut self) -> Renderer {
-        unsafe {
-            ul::ulAppGetRenderer(self.app)
+        unsafe { ul::ulAppGetRenderer(self.app) }
+    }
+
+    pub fn get_view(&mut self) -> Result<View, ()> {
+        if let Some(overlay) = self.overlay {
+            unsafe { Ok(ul::ulOverlayGetView(overlay)) }
+        } else {
+            Err(())
         }
     }
 
-    pub fn get_view(&mut self) -> Result<View, NoneError> {
-        unsafe {
-            Ok(ul::ulOverlayGetView(self.overlay?))
+    pub fn set_window_title(&mut self, title: &str) -> Result<(), ()> {
+        if let Some(window) = self.window {
+            unsafe {
+                ul::ulWindowSetTitle(window, std::ffi::CString::new(title).unwrap().as_ptr());
+            }
+
+            Ok(())
+        } else {
+            Err(())
         }
     }
 
-    pub fn set_window_title(&mut self, title: &str) -> Result<(), NoneError> {
-        unsafe {
-            ul::ulWindowSetTitle(
-                self.window?,
-                std::ffi::CString::new(title).unwrap().as_ptr()
-            );
-        }
+    pub fn resize_overlay(&self, width: u32, height: u32) -> Result<(), ()> {
+        if let Some(overlay) = self.overlay {
+            unsafe {
+                ul::ulOverlayResize(overlay, width, height);
+            }
 
-        Ok(())
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
-    pub fn resize_overlay(&self, width: u32, height: u32) -> Result<(), NoneError> {
-        unsafe {
-            ul::ulOverlayResize(self.overlay?, width, height);
-        }
-
-        Ok(())
-    }
-
-    pub fn set_window_resize_callback<T>(&self, mut cb: T) -> Result<(), NoneError>
-        where T: FnMut(u32, u32)
+    pub fn set_window_resize_callback<T>(&self, mut cb: T) -> Result<(), ()>
+    where
+        T: FnMut(u32, u32),
     {
-        unsafe {
-            let (
-                cb_closure,
-                cb_function
-            ) = unpack_window_resize_cb(&mut cb);
+        if let Some(window) = self.window {
+            unsafe {
+                let (cb_closure, cb_function) = unpack_window_resize_cb(&mut cb);
 
-            ul::ulWindowSetResizeCallback(
-                self.window?,
-                Some(cb_function),
-                cb_closure
-            );
+                ul::ulWindowSetResizeCallback(window, Some(cb_function), cb_closure);
+            }
+
+            Ok(())
+        } else {
+            Err(())
         }
-
-        Ok(())
     }
 
     pub fn run(&mut self) {
@@ -249,22 +232,18 @@ impl Ultralight {
     pub fn new(config: Option<Config>, renderer: Option<Renderer>) -> Ultralight {
         let ulconfig = match config {
             Some(config) => config,
-            None => Config::new()
+            None => Config::new(),
         };
 
         let used_renderer = match renderer {
             Some(renderer) => renderer,
-            None => {
-                unsafe {
-                    ul::ulCreateRenderer(ulconfig.to_ulconfig())
-                }
-            }
+            None => unsafe { ul::ulCreateRenderer(ulconfig.to_ulconfig()) },
         };
 
         Ultralight {
             config: ulconfig,
             renderer: used_renderer,
-            view: None
+            view: None,
         }
     }
 
@@ -280,24 +259,32 @@ impl Ultralight {
         }
     }
 
-    pub fn load_url(&mut self, url: &'static str) -> Result<(), NoneError> {
-        unsafe {
-            let url_ulstr = helpers_internal::ul_string(url);
+    pub fn load_url(&mut self, url: &'static str) -> Result<(), ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                let url_ulstr = helpers_internal::ul_string(url);
 
-            ul::ulViewLoadURL(self.view?, url_ulstr);
+                ul::ulViewLoadURL(view, url_ulstr);
+            }
+
+            Ok(())
+        } else {
+            Err(())
         }
-
-        Ok(())
     }
 
-    pub fn load_html(&mut self, code: &'static str) -> Result<(), NoneError> {
-        unsafe {
-            let code_ulstr = helpers_internal::ul_string(code);
+    pub fn load_html(&mut self, code: &'static str) -> Result<(), ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                let code_ulstr = helpers_internal::ul_string(code);
 
-            ul::ulViewLoadHTML(self.view?, code_ulstr);
+                ul::ulViewLoadHTML(view, code_ulstr);
+            }
+
+            Ok(())
+        } else {
+            Err(())
         }
-
-        Ok(())
     }
 
     pub fn update(&mut self) {
@@ -306,14 +293,18 @@ impl Ultralight {
         }
     }
 
-    pub fn update_until_loaded(&mut self) -> Result<(), NoneError> {
-        unsafe {
-            while ul::ulViewIsLoading(self.view?) {
-                ul::ulUpdate(self.renderer);
+    pub fn update_until_loaded(&mut self) -> Result<(), ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                while ul::ulViewIsLoading(view) {
+                    ul::ulUpdate(self.renderer);
+                }
             }
-        }
 
-        Ok(())
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     pub fn render(&mut self) {
@@ -322,182 +313,178 @@ impl Ultralight {
         }
     }
 
-    pub fn scroll(&mut self, delta_x: i32, delta_y: i32) -> Result<(), NoneError> {
-        unsafe {
-            let scrollEvent = ul::ulCreateScrollEvent(
-                ul::ULScrollEventType_kScrollEventType_ScrollByPixel,
-                delta_x,
-                delta_y
-            );
+    pub fn scroll(&mut self, delta_x: i32, delta_y: i32) -> Result<(), ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                let scrollEvent = ul::ulCreateScrollEvent(
+                    ul::ULScrollEventType_kScrollEventType_ScrollByPixel,
+                    delta_x,
+                    delta_y,
+                );
 
-            ul::ulViewFireScrollEvent(self.view?, scrollEvent);
+                ul::ulViewFireScrollEvent(view, scrollEvent);
 
-            ul::ulDestroyScrollEvent(scrollEvent);
+                ul::ulDestroyScrollEvent(scrollEvent);
+
+                Ok(())
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn get_scroll_height(&mut self) -> Result<f64, ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                let (jsgctx, _) = helpers::getJSContextFromView(view);
+
+                Ok(ul::JSValueToNumber(
+                    jsgctx,
+                    self.evaluate_script("document.body.scrollHeight").unwrap(),
+                    std::ptr::null_mut(),
+                ))
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn set_finish_loading_callback<T>(&mut self, mut cb: T) -> Result<(), ()>
+    where
+        T: FnMut(View),
+    {
+        if let Some(view) = self.view {
+            unsafe {
+                let (cb_closure, cb_function) = unpack_closure_view_cb(&mut cb);
+
+                ul::ulViewSetFinishLoadingCallback(view, Some(cb_function), cb_closure);
+            }
 
             Ok(())
+        } else {
+            Err(())
         }
     }
 
-    pub fn get_scroll_height(&mut self) -> Result<f64, NoneError> {
-        unsafe {
-            let (jsgctx, _) = helpers::getJSContextFromView(self.view?);
-
-            Ok(ul::JSValueToNumber(
-                jsgctx,
-                self.evaluate_script("document.body.scrollHeight").unwrap(),
-                std::ptr::null_mut()
-            ))
-        }
-    }
-
-    pub fn set_finish_loading_callback<T>(&mut self, mut cb: T) -> Result<(), NoneError>
-        where T: FnMut(View)
+    pub fn set_dom_ready_callback<T>(&mut self, mut cb: T) -> Result<(), ()>
+    where
+        T: FnMut(View),
     {
-        let view = self.view?;
+        if let Some(view) = self.view {
+            unsafe {
+                let (cb_closure, cb_function) = unpack_closure_view_cb(&mut cb);
 
-        unsafe {
-            let (
-                cb_closure,
-                cb_function
-            ) = unpack_closure_view_cb(&mut cb);
+                ul::ulViewSetDOMReadyCallback(view, Some(cb_function), cb_closure);
+            }
 
-            ul::ulViewSetFinishLoadingCallback(
-                view,
-                Some(cb_function),
-                cb_closure
-            );
+            Ok(())
+        } else {
+            Err(())
         }
-
-        Ok(())
-    }
-
-    pub fn set_dom_ready_callback<T>(&mut self, mut cb: T) -> Result<(), NoneError>
-        where T: FnMut(View)
-    {
-        let view = self.view?;
-
-        unsafe {
-            let (
-                cb_closure,
-                cb_function
-            ) = unpack_closure_view_cb(&mut cb);
-
-            ul::ulViewSetDOMReadyCallback(
-                view,
-                Some(cb_function),
-                cb_closure
-            );
-        }
-
-        Ok(())
     }
 
     pub fn create_function<T>(
         &mut self,
         name: &'static str,
-        hook: &mut T
-    ) -> Result<ul::JSObjectRef, NoneError>
-        where T: FnMut(
+        hook: &mut T,
+    ) -> Result<ul::JSObjectRef, ()>
+    where
+        T: FnMut(
             ul::JSContextRef,
             ul::JSObjectRef,
             ul::JSObjectRef,
             usize,
             *const ul::JSValueRef,
             *mut ul::JSValueRef,
-        ) -> ul::JSValueRef
+        ) -> ul::JSValueRef,
     {
-        Ok(
-            create_js_function(
-                self.view?,
-                name,
-                hook
-            )
-        )
+        if let Some(view) = self.view {
+            Ok(create_js_function(view, name, hook))
+        } else {
+            Err(())
+        }
     }
 
     pub fn set_js_object_property(
         &mut self,
         name: &'static str,
-        object: ul::JSObjectRef
-    ) -> Result<(), NoneError> {
-        set_js_object_property(
-            self.view?,
-            name,
-            object
-        );
+        object: ul::JSObjectRef,
+    ) -> Result<(), ()> {
+        if let Some(view) = self.view {
+            set_js_object_property(view, name, object);
 
-        Ok(())
-    }
-
-    pub fn evaluate_script(
-        &mut self,
-        script: &'static str,
-    ) -> Result<ul::JSValueRef, NoneError> {
-        Ok(evaluate_script(self.view?, script))
-    }
-
-    pub fn get_raw_pixels(&mut self) -> Result<Vec<u8>, NoneError> {
-        unsafe {
-            let bitmap_obj = ul::ulViewGetBitmap( self.view? );
-
-            let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
-            let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
-
-            let bitmap_raw = std::slice::from_raw_parts_mut(
-                bitmap as *mut u8,
-                bitmap_size,
-            );
-
-            ul::ulBitmapUnlockPixels(bitmap_obj);
-
-            Ok(bitmap_raw.to_vec())
+            Ok(())
+        } else {
+            Err(())
         }
     }
 
-    pub fn write_png_to_file(
-        &mut self,
-        file_name: &'static str,
-    ) -> Result<bool, NoneError> {
-        unsafe {
-            let bitmap_obj = ul::ulViewGetBitmap( self.view? );
+    pub fn evaluate_script(&mut self, script: &'static str) -> Result<ul::JSValueRef, ()> {
+        if let Some(view) = self.view {
+            Ok(evaluate_script(view, script))
+        } else {
+            Err(())
+        }
+    }
 
-            let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
-            let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
+    pub fn get_raw_pixels(&mut self) -> Result<Vec<u8>, ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                let bitmap_obj = ul::ulViewGetBitmap(view);
 
-            let bitmap_raw = std::slice::from_raw_parts_mut(
-                bitmap as *mut u8,
-                bitmap_size,
-            );
+                let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
+                let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
 
-            let fn_c_str = std::ffi::CString::new(file_name).unwrap();
+                let bitmap_raw = std::slice::from_raw_parts_mut(bitmap as *mut u8, bitmap_size);
 
-            Ok(
-                ul::ulBitmapWritePNG(
-                    bitmap_obj,
-                    fn_c_str.as_ptr()
-                )
-            )
+                ul::ulBitmapUnlockPixels(bitmap_obj);
+
+                Ok(bitmap_raw.to_vec())
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn write_png_to_file(&mut self, file_name: &'static str) -> Result<bool, ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                let bitmap_obj = ul::ulViewGetBitmap(view);
+
+                let bitmap = ul::ulBitmapLockPixels(bitmap_obj);
+                let bitmap_size = ul::ulBitmapGetSize(bitmap_obj);
+
+                let bitmap_raw = std::slice::from_raw_parts_mut(bitmap as *mut u8, bitmap_size);
+
+                let fn_c_str = std::ffi::CString::new(file_name).unwrap();
+
+                Ok(ul::ulBitmapWritePNG(bitmap_obj, fn_c_str.as_ptr()))
+            }
+        } else {
+            Err(())
         }
     }
 
     pub fn is_loading(&self) -> bool {
         match self.view {
-            Some(view) => unsafe {
-                ul::ulViewIsLoading(view)
-            },
-            None => false
+            Some(view) => unsafe { ul::ulViewIsLoading(view) },
+            None => false,
         }
     }
 
-    pub fn log_to_stdout(&mut self) -> Result<(), NoneError> {
-        unsafe {
-            ul::ulViewSetAddConsoleMessageCallback(
-                self.view?,
-                Some(log_forward_cb),
-                std::ptr::null_mut() as *mut c_void
-            );
-        }
+    pub fn log_to_stdout(&mut self) -> Result<(), ()> {
+        if let Some(view) = self.view {
+            unsafe {
+                ul::ulViewSetAddConsoleMessageCallback(
+                    view,
+                    Some(log_forward_cb),
+                    std::ptr::null_mut() as *mut c_void,
+                );
+            }
 
-        Ok(())
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 }


### PR DESCRIPTION
Thanks for these bindings.

I thought it'd be nice to be able to build them with stable rust, and it seems like the unstable features aren't critical.

You might want to reapply `rustfmt` if you merge this, I'm not sure if my settings match yours,.